### PR TITLE
Add Apple silicon compatible env file

### DIFF
--- a/environment_apple_silicon.yml
+++ b/environment_apple_silicon.yml
@@ -1,0 +1,34 @@
+name: dcss
+channels:
+  - apple
+  - huggingface
+  - conda-forge
+  - defaults
+dependencies:
+  - graph-tool
+  - pandas
+  - leidenalg
+  - seaborn
+  - matplotlib
+  - scikit-learn
+  - spacy
+  - spacy-lookups-data
+  - pymc3
+  - cairocffi
+  - pip
+  - numpy
+  - pyldavis
+  - transformers
+  - tensorflow-deps
+  - pip:
+    - beautifulsoup4
+    - gensim
+    - ndlib
+    - networkx
+    - graphviz
+    - python-louvain
+    - pyyaml
+    - tensorflow-macos
+    - tensorflow-metal
+    - torch
+    - dcss


### PR DESCRIPTION
The original environment.yml fails to build on Apple Silicon due to tensorflow and its dependencies. This environment builds succesfully on Apple Silicon - however it is not yet extensively tested. Happy to do the testing if there is a particular notebook or chapter I can run through to stress test it.